### PR TITLE
Add optional LVK posterior-sample KDE likelihood and config integration

### DIFF
--- a/example_inis/simple.ini
+++ b/example_inis/simple.ini
@@ -32,6 +32,20 @@ out_name = ecc
 [backpop.fixed::metallicity]
 value = 0.02
 
+; LVK posterior-sample likelihood (optional)
+; Enable this section to replace the independent Gaussian proxy above with a
+; 2D source-frame KDE over chirp mass and mass ratio from PESummary/LVK samples.
+; For a local file, use samples_path = /path/to/GW150914.h5 instead of event.
+[backpop.gw]
+enabled = false
+event = GW150914
+approximant = C01:Mixed
+use_pe_weights = true
+; catalog = GWTC-2
+; path = GW190412.h5
+; unpack = true
+; outdir = ./lvk_samples
+
 ; Prior info on parameters to vary
 [backpop.var::m1]
 min = 7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,9 @@ dependencies = [
     "sphinx-copybutton",
     "meson",
     "nautilus-sampler",
-    "cosmic-popsynth"
+    "cosmic-popsynth",
+    "pesummary",
+    "arviz"
 ]
 
 # add optional dependencies for docs

--- a/src/backpop/__init__.py
+++ b/src/backpop/__init__.py
@@ -1,4 +1,5 @@
-from . import main, posteriors, phase, consts, files
+from . import main, posteriors, phase, consts, files, gw
 from ._version import __version__
 from .main import BackPop
 from .posteriors import BackPopsteriors
+from .gw import GWLikelihood, load_gw_data

--- a/src/backpop/files.py
+++ b/src/backpop/files.py
@@ -61,10 +61,20 @@ def parse_inifile(ini_file):
     config_dict = {section: dict(config_file.items(section)) for section in config_file.sections()}
 
     config = config_dict["backpop"]
+    if "output_folder" not in config and "filepath" in config:
+        config["output_folder"] = config["filepath"]
+    if "phase_condition" not in config and "phase_select" in config:
+        config["phase_condition"] = config["phase_select"]
+    config.setdefault("output_folder", "")
+    config.setdefault("bpp_columns", "")
+    config.setdefault("bcm_columns", "")
+    config.setdefault("n_bpp_rows", "")
+    config.setdefault("use_bcm", "False")
     for k in ["n_threads", "n_eff", "n_live"]:
         config[k] = int(config[k])
     for k in ["verbose", "resume", "use_bcm"]:
-        config[k] = config[k].lower() in ["true", "1", "yes"]
+        config[k] = str(config[k]).lower() in ["true", "1", "yes"]
+    config["gw"] = config_dict.get("backpop.gw", {})
         
     # make sure all flags are the correct type
     flags = config_dict["bse"]
@@ -119,7 +129,7 @@ def parse_inifile(ini_file):
     else:
         config["bpp_columns"] = BPP_COLUMNS
         
-    if config["use_bcm"] == "true":
+    if config["use_bcm"]:
         if config["bcm_columns"] != "" and config["bcm_columns"].lower() != "none":
             # make sure bcm_columns names are found in BCM_COLUMNS
             config["bcm_columns"] = ast.literal_eval(config["bcm_columns"])

--- a/src/backpop/gw.py
+++ b/src/backpop/gw.py
@@ -1,0 +1,205 @@
+"""Utilities for LVK gravitational-wave posterior-sample likelihoods."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from astropy import units as u
+from astropy.constants import c
+from astropy.cosmology import Planck15 as COSMOLOGY
+from scipy.stats import gaussian_kde
+
+
+@dataclass
+class GWLikelihood:
+    """Container for a 2D source-frame GW KDE likelihood."""
+
+    kde: gaussian_kde
+    q_bounds: tuple[float, float]
+    mc_bounds: tuple[float, float]
+    raw_samples: np.ndarray
+    approximant: str
+
+    def logpdf(self, mass_1: float, mass_2: float) -> float:
+        """Evaluate ``log p(mc_source, q)`` for source-frame component masses."""
+        m_hi = max(mass_1, mass_2)
+        m_lo = min(mass_1, mass_2)
+        if not np.isfinite(m_hi) or not np.isfinite(m_lo) or m_hi <= 0.0 or m_lo <= 0.0:
+            return -np.inf
+
+        q = m_lo / m_hi
+        if q < self.q_bounds[0] or q > self.q_bounds[1]:
+            return -np.inf
+
+        mc = (m_hi * m_lo) ** (3.0 / 5.0) / (m_hi + m_lo) ** (1.0 / 5.0)
+        density = self.kde(np.array([[mc], [q]]))[0]
+        if density <= 0.0 or not np.isfinite(density):
+            return -np.inf
+        return float(np.log(density))
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def zofdL(luminosity_distance_mpc: np.ndarray) -> np.ndarray:
+    """Convert luminosity distance in Mpc to redshift using Planck15 cosmology."""
+    d_l = np.asarray(luminosity_distance_mpc, dtype=float)
+    finite = np.isfinite(d_l)
+    if not np.any(finite):
+        return np.full_like(d_l, np.nan, dtype=float)
+
+    max_d_l = float(np.nanmax(d_l[finite]))
+    z_max = 0.5
+    while COSMOLOGY.luminosity_distance(z_max).to_value(u.Mpc) < max_d_l:
+        z_max *= 2.0
+
+    z_grid = np.linspace(0.0, z_max, 20000)
+    d_grid = COSMOLOGY.luminosity_distance(z_grid).to_value(u.Mpc)
+    return np.interp(d_l, d_grid, z_grid)
+
+
+def ddLdz(redshift: np.ndarray) -> np.ndarray:
+    """Return dD_L/dz in Mpc for the same cosmology used by :func:`zofdL`."""
+    z = np.asarray(redshift, dtype=float)
+    transverse = COSMOLOGY.comoving_transverse_distance(z).to_value(u.Mpc)
+    hubble_distance = (c / COSMOLOGY.H0).to_value(u.Mpc)
+    return transverse + (1.0 + z) * hubble_distance / COSMOLOGY.efunc(z)
+
+
+def _read_samples(samples_source: str | Any, fetch_kwargs: dict[str, Any] | None = None) -> Any:
+    """Read a local PESummary file or fetch public samples by event name."""
+    fetch_kwargs = dict(fetch_kwargs or {})
+    if not isinstance(samples_source, str):
+        return samples_source
+
+    expanded = os.path.expanduser(samples_source)
+    if os.path.exists(expanded):
+        from pesummary.io import read
+
+        return read(expanded, package="gw")
+
+    from pesummary.gw.fetch import fetch_open_samples
+
+    return fetch_open_samples(samples_source, **fetch_kwargs)
+
+
+def _samples_array(samples: Any, *names: str) -> np.ndarray:
+    for name in names:
+        if name in samples:
+            return np.asarray(samples[name], dtype=float)
+    raise KeyError(f"None of the sample parameters {names} were present in the PESummary samples")
+
+
+def _hdi(values: np.ndarray, prob: float = 0.999) -> tuple[float, float]:
+    import arviz as az
+
+    lo, hi = az.hdi(values, hdi_prob=prob)
+    return float(lo), float(hi)
+
+
+def load_gw_data(
+    samples_source: str | Any,
+    approximant: str = "C01:Mixed",
+    use_pe_weights: bool = True,
+    fetch_kwargs: dict[str, Any] | None = None,
+) -> GWLikelihood:
+    """Load LVK posterior samples and build a 2D source-frame ``(mc, q)`` KDE.
+
+    ``samples_source`` may be either a path to a local PESummary-compatible HDF5
+    file, an already-read PESummary object, or an event string such as
+    ``"GW150914"``.  Event strings are downloaded with
+    :func:`pesummary.gw.fetch.fetch_open_samples`; pass options such as
+    ``catalog``, ``path``, ``unpack`` and ``outdir`` through ``fetch_kwargs``.
+    """
+    data = _read_samples(samples_source, fetch_kwargs=fetch_kwargs)
+
+    available = list(data.samples_dict.keys())
+    if approximant not in available:
+        fallback = available[0]
+        print(
+            f"[load_gw_data] '{approximant}' not found; using '{fallback}'. "
+            f"Available: {available}"
+        )
+        approximant = fallback
+
+    samples = data.samples_dict[approximant]
+    m1_det = _samples_array(samples, "mass_1", "mass1", "m1")
+    m2_det = _samples_array(samples, "mass_2", "mass2", "m2")
+    d_l = _samples_array(samples, "luminosity_distance", "luminosity_distance_Mpc", "dist")
+
+    redshift = zofdL(d_l)
+    m1_src = m1_det / (1.0 + redshift)
+    m2_src = m2_det / (1.0 + redshift)
+
+    m_hi = np.maximum(m1_src, m2_src)
+    m_lo = np.minimum(m1_src, m2_src)
+    mc_src = (m_hi * m_lo) ** (3.0 / 5.0) / (m_hi + m_lo) ** (1.0 / 5.0)
+    q_src = m_lo / m_hi
+
+    valid = np.isfinite(mc_src) & np.isfinite(q_src) & np.isfinite(redshift) & (mc_src > 0.0) & (q_src > 0.0)
+    if not np.any(valid):
+        raise ValueError("No finite LVK posterior samples remain after source-frame conversion")
+
+    mc_src = mc_src[valid]
+    q_src = q_src[valid]
+    d_l = d_l[valid]
+    redshift = redshift[valid]
+    m_hi = m_hi[valid]
+
+    if use_pe_weights:
+        jacobian = d_l**2 * (1.0 + redshift) ** 2 * ddLdz(redshift) * m_hi**2 / mc_src
+        weights = 1.0 / jacobian
+        weights = weights / np.sum(weights)
+    else:
+        weights = np.ones(len(mc_src), dtype=float) / len(mc_src)
+
+    q_bounds = _hdi(q_src)
+    mc_bounds = _hdi(mc_src)
+    raw_samples = np.column_stack([mc_src, q_src])
+    kde = gaussian_kde(raw_samples.T, weights=weights)
+
+    print(
+        f"[load_gw_data] 2D KDE ({approximant}): "
+        f"mc=[{mc_bounds[0]:.3f},{mc_bounds[1]:.3f}] M_sun, "
+        f"q=[{q_bounds[0]:.4f},{q_bounds[1]:.4f}]"
+    )
+    return GWLikelihood(kde=kde, q_bounds=q_bounds, mc_bounds=mc_bounds, raw_samples=raw_samples,
+                        approximant=approximant)
+
+
+def load_gw_data_from_config(config: dict[str, Any]) -> GWLikelihood | None:
+    """Build a GW likelihood from the optional ``[backpop.gw]`` config section."""
+    gw_config = config.get("gw", {})
+    if not _as_bool(gw_config.get("enabled"), default=False):
+        return None
+
+    source = gw_config.get("samples_path") or gw_config.get("event") or gw_config.get("source")
+    if not source:
+        raise ValueError("[backpop.gw] requires one of samples_path, event, or source")
+
+    fetch_kwargs: dict[str, Any] = {}
+    for key in ("catalog", "path", "outdir", "version"):
+        value = gw_config.get(key)
+        if value not in (None, "", "None"):
+            fetch_kwargs[key] = value
+    for key in ("unpack", "read_file", "delete_on_exit"):
+        if key in gw_config:
+            fetch_kwargs[key] = _as_bool(gw_config[key])
+
+    if "delete_on_exit" not in fetch_kwargs:
+        fetch_kwargs["delete_on_exit"] = False
+
+    return load_gw_data(
+        source,
+        approximant=gw_config.get("approximant", "C01:Mixed"),
+        use_pe_weights=_as_bool(gw_config.get("use_pe_weights"), default=True),
+        fetch_kwargs=fetch_kwargs,
+    )

--- a/src/backpop/main.py
+++ b/src/backpop/main.py
@@ -11,6 +11,7 @@ from .consts import *
 from .files import parse_inifile
 from .phase import select_phase, add_vsys_from_kicks
 from .posteriors import BackPopsteriors
+from .gw import load_gw_data_from_config
 
 
 __all__ = ["BackPop"]
@@ -60,12 +61,24 @@ class BackPop():
         if self.config["verbose"]:
             print(f"Initializing BackPop with {os.path.split(config_file)[-1]}")
 
-        # create a scipy rv object for the likelihood
-        # NOTE: currently assumes independent Gaussians (no correlated noise)
-        self.rv = multivariate_normal(
-            mean=np.array(self.obs["mean"]),
-            cov=np.diag(np.array(self.obs["sigma"])**2)
-        )
+        # create the requested observational likelihood.  By default BackPop
+        # keeps the existing independent Gaussian proxy; [backpop.gw] switches
+        # to a 2D LVK posterior-sample KDE over source-frame (chirp mass, q).
+        self.gw_likelihood = load_gw_data_from_config(self.config)
+        self.rv = None
+        if self.gw_likelihood is None:
+            self.rv = multivariate_normal(
+                mean=np.array(self.obs["mean"]),
+                cov=np.diag(np.array(self.obs["sigma"])**2)
+            )
+        else:
+            for required in ("mass_1", "mass_2"):
+                if required not in self.obs["out_name"]:
+                    raise ValueError(
+                        "GW KDE likelihood requires observations with "
+                        f"out_name = {required!r} so BackPop can compare the "
+                        "COSMIC remnant masses to the LVK (mc, q) KDE"
+                    )
         
         # initialise the Nautilus prior
         self.prior = Prior()
@@ -175,7 +188,12 @@ class BackPop():
             if self.obs["log"][i]:
                 result[0][i] = np.log10(result[0][i])
 
-        ll = np.sum(self.rv.logpdf(result[0]))
+        if self.gw_likelihood is None:
+            ll = np.sum(self.rv.logpdf(result[0]))
+        else:
+            m1 = result[0][self.obs["out_name"].index("mass_1")]
+            m2 = result[0][self.obs["out_name"].index("mass_2")]
+            ll = self.gw_likelihood.logpdf(m1, m2)
 
         # flatten arrays and force dtype
         bpp_flat = np.array(result[1], dtype=float).ravel()


### PR DESCRIPTION
### Motivation
- Replace the current independent-Gaussian observation proxy with an option to use real LVK posterior samples so population inference can compare COSMIC remnant masses to LVK posterior KDEs over source-frame chirp mass and mass ratio. 
- Allow supplying event names (e.g. `GW150914`) or local PESummary HDF5 files and apply PE-prior Jacobian reweighting to recover likelihoods from posterior samples. 

### Description
- Added `src/backpop/gw.py` implementing `GWLikelihood`, `load_gw_data`, `load_gw_data_from_config`, and helpers (`zofdL`, `ddLdz`, `_read_samples`, `_samples_array`) that build a 2D KDE over `(mc_source, q)` and evaluate `logpdf`. 
- Wired the optional `[backpop.gw]` config section into `BackPop` by adding `load_gw_data_from_config` to `src/backpop/main.py`, making `BackPop` create a `gw_likelihood` when enabled and fall back to the existing Gaussian `rv` otherwise, and using `gw_likelihood.logpdf(mass_1, mass_2)` for likelihood evaluation. 
- Extended config parsing in `src/backpop/files.py` to expose a `gw` subconfig, add compatibility aliases/defaults (`filepath`→`output_folder`, `phase_select`→`phase_condition`), and robust boolean handling; documented usage in `example_inis/simple.ini`. 
- Exported GW utilities from the package (`src/backpop/__init__.py`) and added runtime dependencies `pesummary` and `arviz` to `pyproject.toml`. 

### Testing
- Compiled the package sources with `python -m compileall src/backpop` and confirmed compilation completed without errors. 
- Verified the modified modules parse as valid Python AST with `ast.parse(...)` on `src/backpop/gw.py`, `src/backpop/main.py`, and `src/backpop/files.py`, which succeeded. 
- Ran `pytest -q`, which completed but discovered no tests (no tests were executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a5d3e988832bbe8d7e025a46a8b1)